### PR TITLE
Add statistics dependency and test plugin loading

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   md5: f8ab8e438f039366e3765168ad831b4c
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
@@ -18,15 +18,19 @@ requirements:
     - python
     - setuptools
     - pytest >=2.6
+    - statistics  # [py<34]
 
   run:
     - python
     - setuptools
     - pytest >=2.6
+    - statistics  # [py<34]
 
 test:
   imports:
     - pytest_benchmark
+  commands:
+    - "py.test --traceconfig | grep pytest-benchmark-{{version}}"
 
 about:
   home: https://github.com/ionelmc/pytest-benchmark


### PR DESCRIPTION
The `statistics` package is required for py2k but wasn't available on conda-forge.  It is available now: [conda-forge/statistics-feedstock](/conda-forge/statistics-feedstock).

If the `statistics` package is not available, the plugin silently fails to load and isn't available from the command line `py.test` (though `pytest_benchmark` still imports correctly.)

This PR adds the statistics dependency, adds a test for plugin detection at the command-line, and bumps the build number.